### PR TITLE
Add generic logging of callbacks (Draft)

### DIFF
--- a/src/main/java/com/eclipsesource/v8/LoggableCallback.java
+++ b/src/main/java/com/eclipsesource/v8/LoggableCallback.java
@@ -1,0 +1,7 @@
+package com.eclipsesource.v8;
+
+public interface LoggableCallback {
+
+    public static final String PREFIX = "JS -> Java ";
+
+}

--- a/src/main/java/com/eclipsesource/v8/LoggingJavaCallback.java
+++ b/src/main/java/com/eclipsesource/v8/LoggingJavaCallback.java
@@ -1,0 +1,23 @@
+package com.eclipsesource.v8;
+
+public class LoggingJavaCallback implements LoggableCallback, JavaCallback {
+
+    private JavaCallback delegate;
+    private String       jsFunctionName;
+
+    public LoggingJavaCallback(final JavaCallback delegate, final String jsFunctionName) {
+        this.delegate = delegate;
+        this.jsFunctionName = jsFunctionName;
+    }
+
+    @Override
+    public Object invoke(final V8Array parameters) {
+        log(parameters);
+        return delegate.invoke(parameters);
+    }
+
+    private void log(final V8Array parameters) {
+        System.out.println(PREFIX + jsFunctionName + "(" + parameters + ")");
+    }
+
+}

--- a/src/main/java/com/eclipsesource/v8/LoggingJavaVoidCallback.java
+++ b/src/main/java/com/eclipsesource/v8/LoggingJavaVoidCallback.java
@@ -1,0 +1,23 @@
+package com.eclipsesource.v8;
+
+public class LoggingJavaVoidCallback implements LoggableCallback, JavaVoidCallback {
+
+    private JavaVoidCallback delegate;
+    private String           jsFunctionName;
+
+    public LoggingJavaVoidCallback(final JavaVoidCallback delegate, final String jsFunctionName) {
+        this.delegate = delegate;
+        this.jsFunctionName = jsFunctionName;
+    }
+
+    @Override
+    public void invoke(final V8Array parameters) {
+        log(parameters);
+        delegate.invoke(parameters);
+    }
+
+    private void log(final V8Array parameters) {
+        System.out.println(PREFIX + jsFunctionName + "(" + parameters + ")");
+    }
+
+}


### PR DESCRIPTION
Logs all callbacks from JS to Java.
When logging is disabled, it should have zero runtime overhead.
The logging can be enabled by using the constants
CALLBACK_LOGGING_ENABLED and VOID_CALLBACK_LOGGING_ENABLED.