### PR TITLE
executing null scripts causes a crash

### DIFF
--- a/src/main/java/com/eclipsesource/v8/V8.java
+++ b/src/main/java/com/eclipsesource/v8/V8.java
@@ -167,6 +167,7 @@ public class V8 extends V8Object {
 
     public int executeIntScript(final String script, final String scriptName, final int lineNumber) {
         checkThread();
+        checkScript(script);
         return _executeIntScript(v8RuntimeHandle, script, scriptName, lineNumber);
     }
 
@@ -176,6 +177,7 @@ public class V8 extends V8Object {
 
     public double executeDoubleScript(final String script, final String scriptName, final int lineNumber) {
         checkThread();
+        checkScript(script);
         return _executeDoubleScript(v8RuntimeHandle, script, scriptName, lineNumber);
     }
 
@@ -185,6 +187,7 @@ public class V8 extends V8Object {
 
     public String executeStringScript(final String script, final String scriptName, final int lineNumber) {
         checkThread();
+        checkScript(script);
         return _executeStringScript(v8RuntimeHandle, script, scriptName, lineNumber);
     }
 
@@ -194,6 +197,7 @@ public class V8 extends V8Object {
 
     public boolean executeBooleanScript(final String script, final String scriptName, final int lineNumber) {
         checkThread();
+        checkScript(script);
         return _executeBooleanScript(v8RuntimeHandle, script, scriptName, lineNumber);
     }
 
@@ -216,6 +220,7 @@ public class V8 extends V8Object {
 
     public Object executeScript(final String script, final String scriptName, final int lineNumber) {
         checkThread();
+        checkScript(script);
         return _executeScript(getV8RuntimeHandle(), UNKNOWN, script, scriptName, lineNumber);
     }
 
@@ -238,12 +243,19 @@ public class V8 extends V8Object {
 
     public void executeVoidScript(final String script, final String scriptName, final int lineNumber) {
         checkThread();
+        checkScript(script);
         _executeVoidScript(v8RuntimeHandle, script, scriptName, lineNumber);
     }
 
     static void checkThread() {
         if ((thread != null) && (thread != Thread.currentThread())) {
             throw new Error("Invalid V8 thread access.");
+        }
+    }
+
+    static void checkScript(final String script) {
+        if (script == null) {
+            throw new NullPointerException("Script is null");
         }
     }
 

--- a/src/test/java/com/eclipsesource/v8/AllTests.java
+++ b/src/test/java/com/eclipsesource/v8/AllTests.java
@@ -20,7 +20,8 @@ import com.eclipsesource.v8.utils.tests.V8ObjectUtilsTest;
 // V8RuntimeNotLoadedTest must be run first. This is because we need to test when the natives are not loaded
 // and once the V8 class is loaded we cannot unload it.
 @SuiteClasses({ V8RuntimeNotLoadedTest.class, LibraryLoaderTest.class, V8ObjectTest.class, V8Test.class, V8ArrayTest.class, V8JSFunctionCallTest.class,
-        V8CallbackTest.class, V8ScriptCompilationExceptionTest.class, V8ScriptExecutionExceptionTest.class, V8ObjectUtilsTest.class, V8TypedArraysTest.class })
+        V8CallbackTest.class, V8ScriptCompilationExceptionTest.class, V8ScriptExecutionExceptionTest.class, V8ObjectUtilsTest.class, V8TypedArraysTest.class,
+        NullScriptExecuteTest.class })
 public class AllTests {
 
 }

--- a/src/test/java/com/eclipsesource/v8/NullScriptExecuteTest.java
+++ b/src/test/java/com/eclipsesource/v8/NullScriptExecuteTest.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * 	Contributors:
+ * 		 Red Hat Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.eclipsesource.v8;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class NullScriptExecuteTest {
+
+    private V8 v8;
+
+    @Before
+    public void setup() {
+        v8 = V8.createV8Runtime();
+    }
+
+    @After
+    public void tearDown() {
+        try {
+            v8.release();
+            if (V8.getActiveRuntimes() != 0) {
+                throw new IllegalStateException("V8Runtimes not properly released.");
+            }
+        } catch (IllegalStateException e) {
+            System.out.println(e.getMessage());
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testStringScript() {
+        v8.executeStringScript(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testArrayScript() {
+        v8.executeArrayScript(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testBooleancript() {
+        v8.executeBooleanScript(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testDoubleScript() {
+        v8.executeDoubleScript(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testIntScript() {
+        v8.executeIntScript(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testObjectScript() {
+        v8.executeObjectScript(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testScript() {
+        v8.executeScript(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullStringScript() {
+        v8.executeVoidScript(null);
+    }
+
+
+}


### PR DESCRIPTION
Passing a null script value to any of the execute script methods causes VM to crash. This adds null checks and throws a NPE when appropriate. Also includes tests 