### PR TITLE
Add Maven Central link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 J2V8
 ====
 
+[![Maven Central](https://img.shields.io/maven-central/v/com.eclipsesource.j2v8/j2v8_win32_x8.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.eclipsesource.j2v8%22)
+
 J2V8 is a set of Java bindings for V8. J2V8 focuses on performance and tight integration with V8. It also takes a 'primitive first' approach, meaning that if a value can be accessed as a primitive, then it should be. This forces a more static type system between the JS and Java code, but it also improves the performance since intermediate Objects are not created.
 
 Articles


### PR DESCRIPTION
This PR adds a link to the maven central. As J2V8 provides an artifact per OS, the image link  is for win32 (but I think you build the whole OS artifacts in the same time).