### PR TITLE
Add Who is using J2V8 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,12 @@ Articles
  * [Announcing J2V8 2.0](http://eclipsesource.com/blogs/2015/02/25/announcing-j2v8-2-0/)
  * [Highly Efficient Java & JavaScript Integration](http://eclipsesource.com/blogs/2014/11/17/highly-efficient-java-javascript-integration/)
 
+Who is using J2V8?
+========
+
+Here are some projects that use J2V8:
+
+* [tern.java](https://github.com/angelozerr/tern.java)
+ 
 ## License
 The code is published under the terms of the [Eclipse Public License, version 1.0](http://www.eclipse.org/legal/epl-v10.html).


### PR DESCRIPTION
I think it's a good idea to show projects which uses J2V8 like minimal-json have done.

I have added tern.java (even if it's not finished because I'm waiting OSGify + release).