### PR TITLE
Added support for BB10 Android Runtime

### DIFF
--- a/src/main/java/com/eclipsesource/v8/LibraryLoader.java
+++ b/src/main/java/com/eclipsesource/v8/LibraryLoader.java
@@ -165,6 +165,10 @@ class LibraryLoader {
         return getOsName().startsWith("nacl");
     }
 
+    static boolean isBB10Client() {
+        return getOsName().startsWith("qnx");
+    }
+
     static boolean isAndroid() {
         return getOsName().contains("Android");
     }
@@ -179,6 +183,8 @@ class LibraryLoader {
             return "armv7l";
         } else if (arch.equals("aarch64")) {
             return "armv7l";
+        } else if (isBB10Client()) {
+            return "armv7l";
         }
         return arch;
     }
@@ -192,6 +198,8 @@ class LibraryLoader {
             return "so";
         } else if (isNativeClient()) {
             return "so";
+        } else if (isBB10Client()) {
+            return "so";
         }
         throw new UnsatisfiedLinkError("Unsupported platform: " + getOsName() + ".");
     }
@@ -201,9 +209,9 @@ class LibraryLoader {
             return "win32";
         } else if (isMac()) {
             return "macosx";
-        } else if (isLinux() && !isAndroid()) {
+        } else if (isLinux() && !(isAndroid() || isBB10Client())) {
             return "linux";
-        } else if (isAndroid()) {
+        } else if (isAndroid() || isBB10Client()) {
             return "android";
         }
         throw new UnsatisfiedLinkError("Unsupported platform: " + getOsName() + ".");


### PR DESCRIPTION
I was trying the library in a BlackBerry 10 device. The library crashed because the LibaryLoader class was failing to pass the tests. Since BlackBerry 10 has support for ARMv5TE and ARMv7-A architectures (https://developer.blackberry.com/android/apisupport/android_native_support.html), just by altering the checks in this class, you can make it support the Blackberry 10 Android Runtime. 

Thanks!