### PR TITLE
Set null instead of undefined in V8Objects for null values in Java Map

### DIFF
--- a/src/main/java/com/eclipsesource/v8/utils/V8ObjectUtils.java
+++ b/src/main/java/com/eclipsesource/v8/utils/V8ObjectUtils.java
@@ -369,7 +369,7 @@ public class V8ObjectUtils {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private static void pushValue(final V8 v8, final V8Array result, final Object value, final Map<Object, V8Object> cache) {
         if (value == null) {
-            result.pushUndefined();
+            result.pushNull();
         } else if (value instanceof Integer) {
             result.push((Integer) value);
         } else if (value instanceof Long) {
@@ -396,7 +396,7 @@ public class V8ObjectUtils {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private static void setValue(final V8 v8, final V8Object result, final String key, final Object value, final Map<Object, V8Object> cache) {
         if (value == null) {
-            result.addUndefined(key);
+            result.addNull(key);
         } else if (value instanceof Integer) {
             result.add(key, (Integer) value);
         } else if (value instanceof Long) {


### PR DESCRIPTION
This changes `V8ObjectUtils.toV8Object()` so that it sets `null` instead of `undefined` when it encounters a `null` value in the Java Map.

I appreciate that it may not always be clear which is better. I did wonder about adding a boolean flag to the public interface, or a parallel `toV8ObjectUseNull()` instead, but I wanted to solicit feedback first. My opinion is that if a Java Map does contain an entry with a `null` value, then it got there because someone explicitly put it there, so the semantics of the JS `null` fit better than `undefined`. I could be wrong, though.

In any event, this change does fix a specific bug I encountered where a JS library was handling `null` and `undefined` differently.
