### PR TITLE
Allow V8Object values in V8ObjectUtils.toV8Array and V8ObjectUtils.toV8Object

### DIFF
--- a/src/main/java/com/eclipsesource/v8/utils/V8ObjectUtils.java
+++ b/src/main/java/com/eclipsesource/v8/utils/V8ObjectUtils.java
@@ -382,6 +382,8 @@ public class V8ObjectUtils {
             result.push((String) value);
         } else if (value instanceof Boolean) {
             result.push((Boolean) value);
+        } else if (value instanceof V8Object) {
+            result.push((V8Object) value);
         } else if (value instanceof Map) {
             V8Object object = toV8Object(v8, (Map) value, cache);
             result.push(object);
@@ -409,6 +411,8 @@ public class V8ObjectUtils {
             result.add(key, (String) value);
         } else if (value instanceof Boolean) {
             result.add(key, (Boolean) value);
+        } else if (value instanceof V8Object) {
+            result.add(key, (V8Object) value);
         } else if (value instanceof Map) {
             V8Object object = toV8Object(v8, (Map) value, cache);
             result.add(key, object);


### PR DESCRIPTION
This adds the ability to:

- have a `V8Object` value in a Java List when converting to a `V8Array` with `V8ObjectUtils.toV8Array()`
- have a `V8Object` value in a Java Map when converting to a `V8Object` with `V8ObjectUtils.toV8Object()`