### PR TITLE
Update node version to v 6.1.0

### DIFF
--- a/build-node.sh
+++ b/build-node.sh
@@ -1,6 +1,6 @@
 git clone https://github.com/nodejs/node.git
 cd node
-git checkout v5.9.1
+git checkout v6.1.0
 ./configure --enable-static
 make
 cd ..

--- a/src/test/java/com/eclipsesource/v8/V8Test.java
+++ b/src/test/java/com/eclipsesource/v8/V8Test.java
@@ -64,7 +64,7 @@ public class V8Test {
     public void testGetVersion_StartsWith4() {
         String v8version = V8.getV8Version();
 
-        assertTrue(v8version.startsWith("4"));
+        assertTrue(v8version.startsWith("5"));
     }
 
     @Test


### PR DESCRIPTION
Hello and thanks for J2V8.

On my mac, I noticed that upgrading node to v6.1.0 did not cause any compile error generating the dylib.

Node 6.0.0 has several advantages:

* 99% [ES 2015 compatibility](node.green) through v8 v5.0.71.35
* It makes ordering of the Object.assign() keys compliant with the spec. It seems boring but it actually solves a [very nasty bug](https://github.com/facebook/react/issues/6451) with React Server-side rendering.

I just wanted to begin this discussion with you and know why node version hasn't been updated recently.

v6.1.0 is the upper major version which compiles without errors when linking the binary (6.2.0 fails with errors beyond my skill level).
We could probably pinpoint the exact commit that introduces changes in C++ API with git bisect if we choose to keep updating the lib.

I realize this is a big effort in testing and I'm also interested in any guidance you can provide regarding testing, QA and CI.
I would be more than happy to contribute to the documentation as well.