### PR TITLE
V8locker: minor improvements to release and checkThread()

### DIFF
--- a/src/main/java/com/eclipsesource/v8/V8Locker.java
+++ b/src/main/java/com/eclipsesource/v8/V8Locker.java
@@ -19,6 +19,7 @@ package com.eclipsesource.v8;
 public class V8Locker {
 
     private Thread thread = null;
+    private boolean released = false;
 
     V8Locker() {
         acquire();
@@ -43,6 +44,7 @@ public class V8Locker {
             throw new Error("Invalid V8 thread access: current thread is " + Thread.currentThread() + " while the locker has thread " + thread);
         }
         thread = Thread.currentThread();
+        released = false;
     }
 
     /**
@@ -57,6 +59,7 @@ public class V8Locker {
             return false;
         }
         thread = Thread.currentThread();
+        released = false;
         return true;
     }
 
@@ -68,6 +71,7 @@ public class V8Locker {
     public synchronized void release() {
         checkThread();
         thread = null;
+        released = true;
     }
 
     /**
@@ -76,6 +80,9 @@ public class V8Locker {
      * is thrown.
      */
     public void checkThread() {
+        if(released && thread == null){
+            throw new Error("Invalid V8 thread access: the locker has been released!");
+        }
         if ((thread != Thread.currentThread())) {
             throw new Error("Invalid V8 thread access: current thread is " + Thread.currentThread() + " while the locker has thread " + thread);
         }

--- a/src/main/java/com/eclipsesource/v8/V8Locker.java
+++ b/src/main/java/com/eclipsesource/v8/V8Locker.java
@@ -66,9 +66,13 @@ public class V8Locker {
     /**
      * Release the lock if it's currently held by the calling thread.
      * If the current thread does not hold the lock, and error will be
-     * thrown.
+     * thrown. If no thread holds the lock then nothing will happen.
      */
     public synchronized void release() {
+        if(released && thread == null){
+            return;
+        }
+
         checkThread();
         thread = null;
         released = true;


### PR DESCRIPTION
In this pull request I have included some minor changes to V8Locker.  Basically what was going on is if release was called more than once it would throw an error. Because the current thread is null. This should ensure that checkThread should never compare a null thread. Basically if there isn't a lock on the locker then it throws less errors.