### PR TITLE
Support for Alpine Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,15 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(J2V8_LIB_PLATFORM_NAME "linux")
     set(J2V8_LIB_PREFIX "")
     set(J2V8_LIB_ARCH_NAME "x86")
+
+    # TODO: This hack could be used to have a different lib filename for alpine, e.g. libj2v8_alpine_x86_64
+    # However, this would require java code changes to account for the different filename
+    # Source: https://github.com/dotnet/coreclr/pull/5731/files
+    #EXEC_PROGRAM(uname ARGS -v OUTPUT_VARIABLE CMAKE_SYSTEM_KERNEL_VERSION)
+    #string(FIND "${CMAKE_SYSTEM_KERNEL_VERSION}" "Alpine" PAL_SYSTEM_ALPINE)
+    #if(PAL_SYSTEM_ALPINE EQUAL -1)
+    #    set(J2V8_LIB_PLATFORM_NAME "alpine")
+    #endif()
 #}
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 #{

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,14 +47,10 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(J2V8_LIB_PREFIX "")
     set(J2V8_LIB_ARCH_NAME "x86")
 
-    # TODO: This hack could be used to have a different lib filename for alpine, e.g. libj2v8_alpine_x86_64
-    # However, this would require java code changes to account for the different filename
-    # Source: https://github.com/dotnet/coreclr/pull/5731/files
-    #EXEC_PROGRAM(uname ARGS -v OUTPUT_VARIABLE CMAKE_SYSTEM_KERNEL_VERSION)
-    #string(FIND "${CMAKE_SYSTEM_KERNEL_VERSION}" "Alpine" PAL_SYSTEM_ALPINE)
-    #if(PAL_SYSTEM_ALPINE EQUAL -1)
-    #    set(J2V8_LIB_PLATFORM_NAME "alpine")
-    #endif()
+    # Set a different lib filename for alpine, to differentiate from glibc linux
+    if(EXISTS /etc/alpine-release)
+        set(J2V8_LIB_PLATFORM_NAME "alpine")
+    endif()
 #}
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 #{

--- a/build.py
+++ b/build.py
@@ -10,6 +10,7 @@ from build_system.shell_build import ShellBuildSystem
 
 from build_system.config_android import android_config
 from build_system.config_linux import linux_config
+from build_system.config_alpine import alpine_config
 from build_system.config_macos import macos_config
 from build_system.config_win32 import win32_config
 
@@ -34,6 +35,7 @@ composite_steps = [
 avail_targets = {
     c.target_android: android_config,
     c.target_linux: linux_config,
+    c.target_alpine: alpine_config,
     c.target_macos: macos_config,
     c.target_win32: win32_config,
 }
@@ -53,6 +55,7 @@ parser.add_argument("--target", "-t",
                     choices=[
                         c.target_android,
                         c.target_linux,
+                        c.target_alpine,
                         c.target_macos,
                         c.target_win32,
                     ])

--- a/build_system/config_alpine.py
+++ b/build_system/config_alpine.py
@@ -1,0 +1,25 @@
+import constants as c
+from cross_build import BuildStep, PlatformConfig
+from docker_build import DockerBuildSystem
+import config_linux as lc
+
+alpine_config = PlatformConfig(c.target_alpine, [c.arch_x86, c.arch_x64], DockerBuildSystem)
+
+alpine_config.cross_config(BuildStep(
+    name="cross-compile-host",
+    platform=c.target_alpine,
+    host_cwd="$CWD/docker",
+    build_cwd="/j2v8",
+))
+
+alpine_config.set_file_abis({
+    c.arch_x64: "x86_64",
+    c.arch_x86: "x86"
+})
+
+# Alpine build steps are the same as for linux  - just the build environment is different
+alpine_config.build_step(c.build_node_js, lc.build_node_js)
+alpine_config.build_step(c.build_j2v8_cmake, lc.build_j2v8_cmake)
+alpine_config.build_step(c.build_j2v8_jni, lc.build_j2v8_jni)
+alpine_config.build_step(c.build_j2v8_java, lc.build_j2v8_java)
+alpine_config.build_step(c.build_j2v8_junit, lc.build_j2v8_junit)

--- a/build_system/constants.py
+++ b/build_system/constants.py
@@ -1,6 +1,7 @@
 # target platforms
 target_android = 'android'
 target_linux = 'linux'
+target_alpine = 'alpine'
 target_macos = 'macos'
 target_win32 = 'win32'
 

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,0 +1,23 @@
+FROM library/openjdk:8u131-alpine
+
+RUN mkdir -p /temp/docker/shared/
+WORKDIR /temp/docker/shared/
+
+# NOTE: copy shared scripts and run them separately
+# this helps when changing commands only in a single script,
+# since it will not requrie rebuilding all docker image layers
+# but just the ones that were affected
+
+COPY ./shared/install.alpine.packages.sh /temp/docker/shared
+RUN ./install.alpine.packages.sh
+
+COPY ./shared/install.maven.sh /temp/docker/shared
+RUN ./install.maven.sh
+ENV PATH "$PATH:/opt/apache-maven-3.5.0/bin"
+
+# download the most critical maven dependencies for the build beforehand
+COPY ./shared/pom.xml /temp
+WORKDIR /temp
+RUN export J2V8_PLATFORM_NAME=temp && \
+    export J2V8_ARCH_NAME=temp && \
+    mvn verify -DskipTests || true

--- a/docker/shared/install.alpine.packages.sh
+++ b/docker/shared/install.alpine.packages.sh
@@ -1,0 +1,16 @@
+
+echo "Preparing Alpine packages..."
+apk add --update --no-cache \
+	git \
+	unzip \
+	gcc \
+	g++ \
+	curl \
+	file \
+	python \
+	make \
+	cmake \
+	wget \
+	supervisor \
+	bash \
+	linux-headers

--- a/docker/shared/install.maven.sh
+++ b/docker/shared/install.maven.sh
@@ -1,5 +1,6 @@
 
 echo "Preparing Maven..."
 curl http://www-eu.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.tar.gz -O
+mkdir -p /opt
 tar xzvf apache-maven-3.5.0-bin.tar.gz -C /opt/
 chmod -R 777 /opt/apache-maven-3.5.0

--- a/src/main/java/com/eclipsesource/v8/LibraryLoader.java
+++ b/src/main/java/com/eclipsesource/v8/LibraryLoader.java
@@ -169,6 +169,20 @@ class LibraryLoader {
         return getOsName().startsWith("Linux");
     }
 
+    /**
+     * Source: Adjusted from https://stackoverflow.com/a/20624914
+     */
+    static boolean isAlpine() {
+        try {
+            java.util.Scanner s = new java.util.Scanner(
+                Runtime.getRuntime().exec("cat /etc/alpine-release").getInputStream()
+            ).useDelimiter("\\A");
+            return s.hasNext();
+        } catch (IOException exception){
+            return false;
+        }
+    }
+
     static boolean isNativeClient() {
         return getOsName().startsWith("nacl");
     }
@@ -209,6 +223,9 @@ class LibraryLoader {
             return "win32";
         } else if (isMac()) {
             return "macosx";
+        } else if (isAlpine() && !isAndroid()) {
+            // Alpine has to be checked before, because isLinux is true for Alpine, too
+            return "alpine";
         } else if (isLinux() && !isAndroid()) {
             return "linux";
         } else if (isAndroid()) {

--- a/src/test/java/com/eclipsesource/v8/LibraryLoaderTest.java
+++ b/src/test/java/com/eclipsesource/v8/LibraryLoaderTest.java
@@ -47,7 +47,12 @@ public class LibraryLoaderTest {
     public void testGetOSLinux() {
         System.setProperty("os.name", "Linux");
 
-        assertEquals("linux", LibraryLoader.getOS());
+        // Alpine is a linux flavor
+        if(LibraryLoader.isAlpine()){
+            assertEquals("alpine", LibraryLoader.getOS());
+        } else {
+            assertEquals("linux", LibraryLoader.getOS());
+        }
     }
 
     @Test


### PR DESCRIPTION
This adds support for building a musl flavored J2V8 version, by providing a Alpine dockerfile to cross-compile J2V8 inside.

Also fixes install.maven.sh in case install.java.sh was not run beforehand (opt folder creation)