### PR TITLE
Docker build based on Debian Jessie - glibc 2.19

### DIFF
--- a/docker/android/Dockerfile
+++ b/docker/android/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:zesty
+FROM debian:jessie
 
 RUN mkdir -p /temp/docker/shared/
 WORKDIR /temp/docker/shared/
@@ -10,6 +10,10 @@ WORKDIR /temp/docker/shared/
 
 COPY ./shared/install.debian.packages.sh /temp/docker/shared
 RUN ./install.debian.packages.sh
+
+COPY ./shared/install.cmake.sh /temp/docker/shared
+RUN ./install.cmake.sh
+ENV PATH "$PATH:/opt/cmake/bin"
 
 ENV NDK_VERSION "r13b"
 ENV NDK_NAME "android-ndk-$NDK_VERSION-linux-x86_64"

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:zesty
+FROM debian:jessie
 
 RUN mkdir -p /temp/docker/shared/
 WORKDIR /temp/docker/shared/
@@ -10,6 +10,10 @@ WORKDIR /temp/docker/shared/
 
 COPY ./shared/install.debian.packages.sh /temp/docker/shared
 RUN ./install.debian.packages.sh
+
+COPY ./shared/install.cmake.sh /temp/docker/shared
+RUN ./install.cmake.sh
+ENV PATH "$PATH:/opt/cmake/bin"
 
 COPY ./shared/install.jdk.sh /temp/docker/shared
 RUN ./install.jdk.sh

--- a/docker/shared/install.debian.packages.sh
+++ b/docker/shared/install.debian.packages.sh
@@ -8,8 +8,8 @@ apt-get -qq update && \
 	g++ g++-multilib \
 	curl \
 	file \
+	execstack \
 	python \
 	make \
-	cmake \
 	wget \
 	supervisor


### PR DESCRIPTION
Motivation:

It is not uncommon to hit linking issues related to glibc version. At the expense of installing cmake manually I decided to go back to debian:jessie instead of ubuntu zesty. This is more production based build. Its is more probable that more people have glibc <= 2.19.

1. Debian Jessie has GLIBC 2.19
2. Debian Stretch has GLIBC 2.24
3. Xenial has GLIBC 2.23
4. Zesty has GLIBC 2.24

Opinions, @drywolf, @irbull 

Going back to jessie.