### PR TITLE
Update readme to include a reference to Alicorn

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Here are some projects that use J2V8:
 * [tern.java](https://github.com/angelozerr/tern.java)
 * [PlantUML](http://plantuml.com/)
 * [jooby](http://jooby.org/doc/assets)
+* [Alicorn](http://alicorn.io)
 
 License
 =====


### PR DESCRIPTION
This commit updates the readme to include a reference to the Alicorn Platform, which makes extensive use of J2V8 and has driven the development of multiple proposed/merged V8 enhancements including concurrent V8 runtimes and better Java class injection.