### PR TITLE
Maven download links in build are broken.

### DIFF
--- a/docker/shared/install.maven.sh
+++ b/docker/shared/install.maven.sh
@@ -1,6 +1,6 @@
 
 echo "Preparing Maven..."
-curl http://www-eu.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.tar.gz -O
+curl http://archive.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.tar.gz -O
 mkdir -p /opt
 tar xzvf apache-maven-3.5.0-bin.tar.gz -C /opt/
 chmod -R 777 /opt/apache-maven-3.5.0

--- a/docker/win32/install.maven.ps1
+++ b/docker/win32/install.maven.ps1
@@ -1,7 +1,7 @@
 
 Write-Host 'Downloading ...';
 C:/j2v8/docker/win32/wget.ps1 `
-    http://www-eu.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.zip `
+    http://archive.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.zip `
     C:\maven.zip
 
 Write-Host 'Installing Maven ...';

--- a/vagrant/macos/Vagrantfile
+++ b/vagrant/macos/Vagrantfile
@@ -26,7 +26,7 @@ SCRIPT
 
 $provision_maven = <<SCRIPT
 echo Downloading Maven...
-curl http://www-eu.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.tar.gz -O
+curl http://archive.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.tar.gz -O
 
 echo Installing Maven...
 sudo tar xzvf apache-maven-3.5.0-bin.tar.gz -C /opt/


### PR DESCRIPTION
Fix download links that currently gives 404 to use http://archive.apache.org instead where the binaries will have a permanent home.

Fixes #360 

I have signed the CLA.