### PR TITLE
Support for arm64-v8a on Android

### DIFF
--- a/build_system/build_configs.py
+++ b/build_system/build_configs.py
@@ -27,6 +27,15 @@ configs = [
                   "node_enabled": True,
             },
       },
+      {
+            "name": "android-arm64 @ Docker",
+            "params": {
+                  "target": c.target_android,
+                  "arch": c.arch_arm64,
+                  "docker": True,
+                  "node_enabled": True,
+            },
+      },
       # ALPINE LINUX builds
       {
             "name": "alpine-linux-x64 @ Docker",

--- a/build_system/build_constants.py
+++ b/build_system/build_constants.py
@@ -63,4 +63,5 @@ avail_architectures = [
     c.arch_x86,
     c.arch_x64,
     c.arch_arm,
+    c.arch_arm64
 ]

--- a/build_system/config_android.py
+++ b/build_system/config_android.py
@@ -5,7 +5,7 @@ import shared_build_steps as u
 import build_utils as b
 import cmake_utils as cmu
 
-android_config = PlatformConfig(c.target_android, [c.arch_x86, c.arch_arm])
+android_config = PlatformConfig(c.target_android, [c.arch_x86, c.arch_arm, c.arch_arm64])
 
 android_config.set_cross_configs({
     "docker": DockerBuildStep(
@@ -21,7 +21,8 @@ android_config.set_cross_compilers({
 
 android_config.set_file_abis({
     c.arch_arm: "armeabi-v7a",
-    c.arch_x86: "x86"
+    c.arch_x86: "x86",
+    c.arch_arm64: "arm64-v8a"
 })
 
 #-----------------------------------------------------------------------

--- a/build_system/config_android.py
+++ b/build_system/config_android.py
@@ -28,7 +28,7 @@ android_config.set_file_abis({
 #-----------------------------------------------------------------------
 def build_node_js(config):
     return [
-        """android-gcc-toolchain $ARCH --api 17 --host gcc-lpthread -C \
+        """android-gcc-toolchain $ARCH --api 21 --host gcc-lpthread -C \
             sh -c \"                \\
             cd ./node;              \\
             ./configure             \\

--- a/build_system/constants.py
+++ b/build_system/constants.py
@@ -13,6 +13,7 @@ vendor_debian = 'debian'
 arch_x86 = 'x86'
 arch_x64 = 'x64'
 arch_arm = 'arm'
+arch_arm64 = 'arm64'
 
 # atomic build-steps
 build_node_js = 'nodejs'

--- a/build_system/docker_build.py
+++ b/build_system/docker_build.py
@@ -36,7 +36,7 @@ class DockerBuildSystem(BuildSystem):
             if (server_match is None or server_match.group(1) is None):
                 utils.cli_exit("ERROR: Unable to determine docker server version from version string: \n\n" + version_str)
 
-            version_match = re.search(r"^ OS/Arch:\s+(.*)$", server_match.group(1), re.MULTILINE)
+            version_match = re.search(r"^  OS/Arch:\s+(.*)$", server_match.group(1), re.MULTILINE)
 
             if (version_match is None):
                 utils.cli_exit("ERROR: Unable to determine docker server platform from version string: \n\n" + version_str)

--- a/docker/android/Dockerfile
+++ b/docker/android/Dockerfile
@@ -49,7 +49,7 @@ RUN mkdir /usr/local/android-sdk/tools/keymaps && \
     touch /usr/local/android-sdk/tools/keymaps/en-us
 
 # install the required license for sdk-build-tools
-RUN mkdir -p $ANDROID_HOME/licenses && echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55\n" > $ANDROID_HOME/licenses/android-sdk-license
+RUN mkdir -p $ANDROID_HOME/licenses && echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e\n" > $ANDROID_HOME/licenses/android-sdk-license
 
 # java must be installed at this point, because the following android CLI commands depend on it
 COPY ./shared/install.jdk.sh /temp/docker/shared

--- a/docker/android/android.arm64.toolchain.cmake
+++ b/docker/android/android.arm64.toolchain.cmake
@@ -1,0 +1,7 @@
+set(CMAKE_SYSTEM_NAME Android)
+set(CMAKE_SYSTEM_VERSION 21) # API level
+
+set(CMAKE_ANDROID_ARCH arm)
+set(CMAKE_ANDROID_ARCH_ABI arm64-v8a)
+set(CMAKE_ANDROID_NDK /build/android-ndk-r13b/)
+set(CMAKE_ANDROID_STL_TYPE gnustl_static)

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,3 +1,3 @@
-APP_ABI := armeabi-v7a x86
+APP_ABI := armeabi-v7a x86 arm64-v8a
 APP_PLATFORM := android-15
 APP_STL=gnustl_static


### PR DESCRIPTION
Adds support for 64-bit ARM on Android. The end result seems to work in my apps at least. Not sure if this is done in a way that's proper for the project; maybe someone can help me out if not.

I tried getting x86_64 on Android working as well, but with less luck.