### PR TITLE
Issue #165: Fail to extract bundle file that's "libj2v8_macosx_x86_64.dylib" in jar file.

### DIFF
--- a/src/main/java/com/eclipsesource/v8/LibraryLoader.java
+++ b/src/main/java/com/eclipsesource/v8/LibraryLoader.java
@@ -31,7 +31,7 @@ class LibraryLoader {
         String base = "j2v8";
         String osSuffix = getOS();
         String archSuffix = getArchSuffix();
-        return base + "_" + osSuffix + "_" + archSuffix;
+        return base + "-" + osSuffix + "-" + archSuffix;
     }
 
     private static String computeLibraryFullName() {


### PR DESCRIPTION
Fix short library name.