### PR TITLE
Implement custom notification on weak reference garbage-collection

### DIFF
--- a/src/main/java/com/eclipsesource/v8/V8Value.java
+++ b/src/main/java/com/eclipsesource/v8/V8Value.java
@@ -212,14 +212,34 @@ abstract public class V8Value implements Releasable {
      * the object will be closed, so this should only be used if there is no
      * other way to track object usage.
      *
+     * @param handler A handler that will be notified when the value weakly-
+     *                referenced by this value is reclaimed by the V8
+     *                garbage collector.
+     * @return The receiver.
+     */
+    public V8Value setWeak(WeakReferenceHandler handler) {
+        v8.checkThread();
+        v8.checkReleased();
+        v8.v8WeakReferences.put(getHandle(), new V8.WeakRefEntry(this, handler));
+        v8.setWeak(v8.getV8RuntimePtr(), getHandle());
+        return this;
+    }
+
+    /**
+     * Sets the V8Value as weak reference. A weak reference will eventually
+     * be closed when no more references exist to this object. Once setWeak
+     * is called, you should check if {@link V8Value#isReleased()} is true
+     * before invoking any methods on this object.
+     *
+     * If any other references exist to this object, the object will not be
+     * reclaimed. Even if no reference exist, V8 does not give any guarantee
+     * the object will be closed, so this should only be used if there is no
+     * other way to track object usage.
+     *
      * @return The receiver.
      */
     public V8Value setWeak() {
-        v8.checkThread();
-        v8.checkReleased();
-        v8.v8WeakReferences.put(getHandle(), this);
-        v8.setWeak(v8.getV8RuntimePtr(), getHandle());
-        return this;
+        return setWeak(null);
     }
 
     /**

--- a/src/main/java/com/eclipsesource/v8/WeakReferenceHandler.java
+++ b/src/main/java/com/eclipsesource/v8/WeakReferenceHandler.java
@@ -1,0 +1,5 @@
+package com.eclipsesource.v8;
+
+public interface WeakReferenceHandler {
+    void v8WeakReferenceCollected(V8Value weakRef);
+}

--- a/src/test/java/com/eclipsesource/v8/V8WeakReferenceHandlerTest.java
+++ b/src/test/java/com/eclipsesource/v8/V8WeakReferenceHandlerTest.java
@@ -1,0 +1,79 @@
+package com.eclipsesource.v8;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class V8WeakReferenceHandlerTest {
+    private V8 v8;
+
+    @Before
+    public void setup() {
+        V8.setFlags("--expose_gc");
+        v8 = V8.createV8Runtime();
+    }
+
+    @After
+    public void tearDown() {
+        try {
+            v8.close();
+            if (V8.getActiveRuntimes() != 0) {
+                throw new IllegalStateException("V8Runtimes not properly released");
+            }
+        } catch (IllegalStateException e) {
+            System.out.println(e.getMessage());
+        }
+    }
+
+    static class WeakReferenceObserver implements WeakReferenceHandler {
+        boolean collected = false;
+        V8Value ref;
+
+        WeakReferenceObserver(V8Value ref) {
+            this.ref = ref;
+        }
+
+        @Override
+        public void v8WeakReferenceCollected(V8Value weakRef) {
+            if (weakRef == ref) {
+                collected = true;
+            } else {
+                throw new IllegalStateException("v8WeakReferenceCollected() called with an unexpected reference");
+            }
+        }
+    }
+
+    @Test
+    public void testReferenceCollectedCalled() {
+        final V8Object o = v8.executeObjectScript(
+                "let a = [];" +
+                "a.push({foo: \"bar\"});"+
+                "a[0];");
+
+        WeakReferenceObserver observer = new WeakReferenceObserver(o);
+
+        o.setWeak(observer);
+
+        Assert.assertFalse(observer.collected);
+        v8.executeVoidScript("a = null");
+        v8.executeVoidScript("gc()");
+        Assert.assertTrue(observer.collected);
+    }
+
+    @Test
+    public void testReferenceCollectedNotCalled() {
+        final V8Object o = v8.executeObjectScript(
+                "let a = [];" +
+                "a.push({foo: \"bar\"});"+
+                "a[0];");
+
+        WeakReferenceObserver observer = new WeakReferenceObserver(o);
+
+        o.setWeak(observer);
+
+        Assert.assertFalse(observer.collected);
+        v8.executeVoidScript("gc()");
+        Assert.assertFalse(observer.collected);
+    }
+}


### PR DESCRIPTION
In our application, we need to be notified when some specific **V8Value** references that have been made weak are garbage-collected by V8, so that we can release some associated object references in the java world too.

This patch adds the ability to optionally set a custom observer on any weak reference. The custom handler is memorized in the **V8.v8WeakReferences** map, and not as a property of the **V8Value**, to avoid the cost of an extra field for all the **V8Value** objects.