### PR TITLE
Update to maven 3.6.0

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -23,7 +23,7 @@ RUN ./install.jdk.sh
 
 COPY ./shared/install.maven.sh /temp/docker/shared
 RUN ./install.maven.sh
-ENV PATH "$PATH:/opt/apache-maven-3.5.0/bin"
+ENV PATH "$PATH:/opt/apache-maven-3.6.0/bin"
 
 COPY ./shared/install.cmake.sh /temp/docker/shared
 RUN ./install.cmake.sh

--- a/docker/shared/install.maven.sh
+++ b/docker/shared/install.maven.sh
@@ -1,6 +1,6 @@
 
 echo "Preparing Maven..."
-curl http://www-eu.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.tar.gz -O
+curl http://www-eu.apache.org/dist/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.tar.gz -O
 mkdir -p /opt
-tar xzvf apache-maven-3.5.0-bin.tar.gz -C /opt/
-chmod -R 777 /opt/apache-maven-3.5.0
+tar xzvf apache-maven-3.6.0-bin.tar.gz -C /opt/
+chmod -R 777 /opt/apache-maven-3.6.0

--- a/docker/win32/install.maven.ps1
+++ b/docker/win32/install.maven.ps1
@@ -1,13 +1,13 @@
 
 Write-Host 'Downloading ...';
 C:/j2v8/docker/win32/wget.ps1 `
-    http://www-eu.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.zip `
+    http://www-eu.apache.org/dist/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.zip `
     C:\maven.zip
 
 Write-Host 'Installing Maven ...';
 C:/j2v8/docker/win32/unzip.ps1 "C:/maven.zip" "C:/"
 
-$env:PATH = 'C:\apache-maven-3.5.0\bin;'+$env:PATH;
+$env:PATH = 'C:\apache-maven-3.6.0\bin;'+$env:PATH;
 [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine);
 
 Write-Host 'Verifying install ...';


### PR DESCRIPTION
Attached is pull request to update Maven to 3.6.0 as Maven 3.5.0 seems to no longer be available per #421.

Don't have ability to review Windows and Andriod.   
Linux built and passed successfully.