### PR TITLE
Add lightweight wrappers for TypedArrays and ArrayBuffers

### DIFF
--- a/src/main/java/com/eclipsesource/v8/utils/ArrayBuffer.java
+++ b/src/main/java/com/eclipsesource/v8/utils/ArrayBuffer.java
@@ -1,0 +1,69 @@
+package com.eclipsesource.v8.utils;
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    EclipseSource - initial API and implementation
+ ******************************************************************************/
+
+import java.nio.ByteBuffer;
+
+import com.eclipsesource.v8.V8;
+import com.eclipsesource.v8.V8ArrayBuffer;
+
+/**
+ * A lightweight handle to a V8TypedArray. This handle provides
+ * access to a V8TypedArray. This handle does not need to be
+ * closed, but if the type array is accessed using getV8TypedArray
+ * then the result must be closed.
+ *
+ * The underlying V8TypedArray may be reclaimed by the JavaScript
+ * garbage collector. To check if it's still available, use
+ * isAvailable.
+ */
+public class ArrayBuffer {
+
+    private V8ArrayBuffer arrayBuffer;
+
+    ArrayBuffer(final V8ArrayBuffer arrayBuffer) {
+        this.arrayBuffer = (V8ArrayBuffer) arrayBuffer.twin().setWeak();
+    }
+
+    /**
+     * Create a new ArrayBuffer from a java.nio.ByteBuffer
+     *
+     * @param v8 the Runtime on which to create the ArrayBuffer
+     * @param byteBuffer the ByteBuffer to use to back the ArrayBuffer
+     */
+    public ArrayBuffer(final V8 v8, final ByteBuffer byteBuffer) {
+        V8ArrayBuffer v8ArrayBuffer = new V8ArrayBuffer(v8, byteBuffer);
+        try {
+            arrayBuffer = (V8ArrayBuffer) v8ArrayBuffer.twin().setWeak();
+        } finally {
+            v8ArrayBuffer.close();
+        }
+    }
+
+    /**
+     * Determine if the underlying V8ArrayBuffer is still available, or if it's been cleaned up by the JavaScript
+     * garbage collector.
+     *
+     * @return true if the underlying V8ArrayBuffer is still available, false otherwise.
+     */
+    public boolean isAvailable() {
+        return !arrayBuffer.isReleased();
+    }
+
+    /**
+     * Returns the underlying V8ArrayBuffer.
+     * @return the underlying V8ArrayBuffer.
+     */
+    public V8ArrayBuffer getV8ArrayBuffer() {
+        return arrayBuffer.twin();
+    }
+
+}

--- a/src/main/java/com/eclipsesource/v8/utils/TypedArray.java
+++ b/src/main/java/com/eclipsesource/v8/utils/TypedArray.java
@@ -1,0 +1,73 @@
+package com.eclipsesource.v8.utils;
+/*******************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    EclipseSource - initial API and implementation
+ ******************************************************************************/
+
+import com.eclipsesource.v8.V8;
+import com.eclipsesource.v8.V8ArrayBuffer;
+import com.eclipsesource.v8.V8TypedArray;
+
+/**
+ * A lightweight handle to a V8TypedArray. This handle provides
+ * access to a V8TypedArray. This handle does not need to be
+ * closed, but if the type array is accessed using getV8TypedArray
+ * then the result must be closed.
+ *
+ * The underlying V8TypedArray may be reclaimed by the JavaScript
+ * garbage collector. To check if it's still available, use
+ * isAvailable.
+ */
+public class TypedArray {
+
+    private V8TypedArray typedArray;
+
+    TypedArray(final V8TypedArray typedArray) {
+        this.typedArray = (V8TypedArray) typedArray.twin().setWeak();
+    }
+
+    /**
+     * Create a new TypedArray from an ArrayBuffer.
+     *
+     * @param v8 the V8Runtime on which to create the TypedArray
+     * @param buffer the ArrayBuffer to use to back the TypedArray
+     * @param type the Type of Array to create
+     * @param offset the Offset into the ArrayBuffer in which to map the TyepdArray
+     * @param size the Size of the TypedArray
+     */
+    public TypedArray(final V8 v8, final ArrayBuffer buffer, final int type, final int offset, final int size) {
+        V8ArrayBuffer v8ArrayBuffer = buffer.getV8ArrayBuffer();
+        V8TypedArray v8typedArray = new V8TypedArray(v8, v8ArrayBuffer, type, offset, size);
+        try {
+            typedArray = (V8TypedArray) v8typedArray.twin().setWeak();
+        } finally {
+            v8ArrayBuffer.close();
+            v8typedArray.close();
+        }
+    }
+
+    /**
+     * Determine if the underlying V8TypedArray is still available, or if it's been cleaned up by the JavaScript
+     * garbage collector.
+     *
+     * @return true if the underlying V8TypedArray is still available, false otherwise.
+     */
+    public boolean isAvailable() {
+        return !typedArray.isReleased();
+    }
+
+    /**
+     * Returns the underlying V8TypedArray.
+     * @return the underlying V8TypedArray.
+     */
+    public V8TypedArray getV8TypedArray() {
+        return (V8TypedArray) typedArray.twin();
+    }
+
+}

--- a/src/test/java/com/eclipsesource/v8/V8CallbackTest.java
+++ b/src/test/java/com/eclipsesource/v8/V8CallbackTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import com.eclipsesource.v8.utils.TypedArray;
 import com.eclipsesource.v8.utils.V8ObjectUtils;
 
 public class V8CallbackTest {
@@ -490,7 +491,7 @@ public class V8CallbackTest {
 
             @Override
             public Boolean invoke(final V8Object receiver, final V8Array parameters) {
-                V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(parameters, 0);
+                V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(parameters, 0)).getV8TypedArray();
                 try {
                     return result.getType() == V8Value.INT_32_ARRAY;
                 } finally {
@@ -511,7 +512,7 @@ public class V8CallbackTest {
 
             @Override
             public Boolean invoke(final V8Object receiver, final V8Array parameters) {
-                V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(parameters, 0);
+                V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(parameters, 0)).getV8TypedArray();
                 try {
                     return result.getType() == V8Value.INT_8_ARRAY;
                 } finally {
@@ -532,7 +533,7 @@ public class V8CallbackTest {
 
             @Override
             public Boolean invoke(final V8Object receiver, final V8Array parameters) {
-                V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(parameters, 0);
+                V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(parameters, 0)).getV8TypedArray();
                 try {
                     return result.getType() == V8Value.INT_16_ARRAY;
                 } finally {
@@ -553,7 +554,7 @@ public class V8CallbackTest {
 
             @Override
             public Boolean invoke(final V8Object receiver, final V8Array parameters) {
-                V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(parameters, 0);
+                V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(parameters, 0)).getV8TypedArray();
                 try {
                     return result.getType() == V8Value.FLOAT_32_ARRAY;
                 } finally {
@@ -574,7 +575,7 @@ public class V8CallbackTest {
 
             @Override
             public Boolean invoke(final V8Object receiver, final V8Array parameters) {
-                V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(parameters, 0);
+                V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(parameters, 0)).getV8TypedArray();
                 try {
                     return result.getType() == V8Value.FLOAT_64_ARRAY;
                 } finally {
@@ -595,7 +596,7 @@ public class V8CallbackTest {
 
             @Override
             public Boolean invoke(final V8Object receiver, final V8Array parameters) {
-                V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(parameters, 0);
+                V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(parameters, 0)).getV8TypedArray();
                 try {
                     return result.getType() == V8Value.UNSIGNED_INT_8_ARRAY;
                 } finally {
@@ -616,7 +617,7 @@ public class V8CallbackTest {
 
             @Override
             public Boolean invoke(final V8Object receiver, final V8Array parameters) {
-                V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(parameters, 0);
+                V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(parameters, 0)).getV8TypedArray();
                 try {
                     return result.getType() == V8Value.UNSIGNED_INT_8_CLAMPED_ARRAY;
                 } finally {
@@ -637,7 +638,7 @@ public class V8CallbackTest {
 
             @Override
             public Boolean invoke(final V8Object receiver, final V8Array parameters) {
-                V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(parameters, 0);
+                V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(parameters, 0)).getV8TypedArray();
                 try {
                     return result.getType() == V8Value.UNSIGNED_INT_16_ARRAY;
                 } finally {
@@ -658,7 +659,7 @@ public class V8CallbackTest {
 
             @Override
             public Boolean invoke(final V8Object receiver, final V8Array parameters) {
-                V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(parameters, 0);
+                V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(parameters, 0)).getV8TypedArray();
                 try {
                     return result.getType() == V8Value.UNSIGNED_INT_32_ARRAY;
                 } finally {

--- a/src/test/java/com/eclipsesource/v8/utils/ArrayBufferTest.java
+++ b/src/test/java/com/eclipsesource/v8/utils/ArrayBufferTest.java
@@ -1,0 +1,51 @@
+package com.eclipsesource.v8.utils;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.ByteBuffer;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.eclipsesource.v8.V8;
+import com.eclipsesource.v8.V8ArrayBuffer;
+
+public class ArrayBufferTest {
+
+    private V8 v8;
+
+    @Before
+    public void seutp() {
+        v8 = V8.createV8Runtime();
+    }
+
+    @After
+    public void tearDown() {
+        if (v8 != null) {
+            v8.close();
+        }
+        if (V8.getActiveRuntimes() != 0) {
+            throw new IllegalStateException("V8Runtimes not properly released");
+        }
+    }
+
+    @Test
+    public void testGetV8ArrayBuffer() {
+        ArrayBuffer arrayBuffer = new ArrayBuffer(v8, ByteBuffer.allocateDirect(8));
+
+        V8ArrayBuffer v8ArrayBuffer = arrayBuffer.getV8ArrayBuffer();
+
+        assertNotNull(v8ArrayBuffer);
+        v8ArrayBuffer.close();
+    }
+
+    @Test
+    public void testV8ArrayBufferAvailable() {
+        ArrayBuffer arrayBuffer = new ArrayBuffer(v8, ByteBuffer.allocateDirect(8));
+
+        assertTrue(arrayBuffer.isAvailable());
+    }
+
+}

--- a/src/test/java/com/eclipsesource/v8/utils/TypedArrayTest.java
+++ b/src/test/java/com/eclipsesource/v8/utils/TypedArrayTest.java
@@ -1,0 +1,52 @@
+package com.eclipsesource.v8.utils;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.ByteBuffer;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.eclipsesource.v8.V8;
+import com.eclipsesource.v8.V8TypedArray;
+import com.eclipsesource.v8.V8Value;
+
+public class TypedArrayTest {
+
+    private V8 v8;
+
+    @Before
+    public void seutp() {
+        v8 = V8.createV8Runtime();
+    }
+
+    @After
+    public void tearDown() {
+        if (v8 != null) {
+            v8.close();
+        }
+        if (V8.getActiveRuntimes() != 0) {
+            throw new IllegalStateException("V8Runtimes not properly released");
+        }
+    }
+
+    @Test
+    public void testGetV8TypedArray() {
+        TypedArray typedArray = new TypedArray(v8, new ArrayBuffer(v8, ByteBuffer.allocateDirect(8)), V8Value.INT_8_ARRAY, 0, 8);
+
+        V8TypedArray v8TypedArray = typedArray.getV8TypedArray();
+
+        assertNotNull(v8TypedArray);
+        v8TypedArray.close();
+    }
+
+    @Test
+    public void testV8TypedArrayAvailable() {
+        TypedArray typedArray = new TypedArray(v8, new ArrayBuffer(v8, ByteBuffer.allocateDirect(8)), V8Value.INT_8_ARRAY, 0, 8);
+
+        assertTrue(typedArray.isAvailable());
+    }
+
+}

--- a/src/test/java/com/eclipsesource/v8/utils/V8ObjectUtilsTest.java
+++ b/src/test/java/com/eclipsesource/v8/utils/V8ObjectUtilsTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -1254,7 +1255,7 @@ public class V8ObjectUtilsTest {
                 + "var root = [buf];\n"
                 + "root;\n");
 
-        V8ArrayBuffer result = (V8ArrayBuffer) V8ObjectUtils.getValue(root, 0);
+        V8ArrayBuffer result = ((ArrayBuffer) V8ObjectUtils.getValue(root, 0)).getV8ArrayBuffer();
 
         assertEquals(100, result.limit());
         root.close();
@@ -1269,7 +1270,7 @@ public class V8ObjectUtilsTest {
                 + "var root = [intsArray];\n"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, 0);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, 0)).getV8TypedArray();
 
         assertEquals(100, result.length());
         assertEquals((byte) 16, result.get(0));
@@ -1284,7 +1285,7 @@ public class V8ObjectUtilsTest {
                 + "var root = [intsArray];\n"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, 0);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, 0)).getV8TypedArray();
 
         assertEquals(24, result.length());
         root.close();
@@ -1299,7 +1300,7 @@ public class V8ObjectUtilsTest {
                 + "var root = [intsArray];\n"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, 0);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, 0)).getV8TypedArray();
 
         assertEquals(100, result.length());
         assertEquals((short) 16, result.get(0));
@@ -1315,7 +1316,7 @@ public class V8ObjectUtilsTest {
                 + "var root = [int8ClampedArray];\n"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, 0);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, 0)).getV8TypedArray();
 
         assertEquals(100, result.length());
         assertEquals((short) 16, result.get(0));
@@ -1331,7 +1332,7 @@ public class V8ObjectUtilsTest {
                 + "var root = [intsArray];\n"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, 0);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, 0)).getV8TypedArray();
 
         assertEquals(50, result.length());
         assertEquals((short) 16, result.get(0));
@@ -1347,7 +1348,7 @@ public class V8ObjectUtilsTest {
                 + "var root = [intsArray];\n"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, 0);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, 0)).getV8TypedArray();
 
         assertEquals(50, result.length());
         assertEquals(16, result.get(0));
@@ -1363,7 +1364,7 @@ public class V8ObjectUtilsTest {
                 + "var root = [intsArray];\n"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, 0);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, 0)).getV8TypedArray();
 
         assertEquals(25, result.length());
         assertEquals(16, result.get(0));
@@ -1380,7 +1381,7 @@ public class V8ObjectUtilsTest {
                 + "var root = [intsArray]\n"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, 0);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, 0)).getV8TypedArray();
 
         assertEquals(25, result.length());
         assertEquals((long) 16, result.get(0));
@@ -1396,7 +1397,7 @@ public class V8ObjectUtilsTest {
                 + "var root = [floatsArray];"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, 0);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, 0)).getV8TypedArray();
 
         assertEquals(25, result.length());
         assertEquals(16.2, (Float) result.get(0), 0.00001);
@@ -1412,7 +1413,7 @@ public class V8ObjectUtilsTest {
                 + "var root = [floatsArray];\n"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, 0);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, 0)).getV8TypedArray();
 
         assertEquals(10, result.length());
         assertEquals(16.2, (Double) result.get(0), 0.0001);
@@ -1426,7 +1427,7 @@ public class V8ObjectUtilsTest {
                 + "var root = { 'items' : buf };\n"
                 + "root;\n");
 
-        V8ArrayBuffer result = (V8ArrayBuffer) V8ObjectUtils.getValue(root, "items");
+        V8ArrayBuffer result = ((ArrayBuffer) V8ObjectUtils.getValue(root, "items")).getV8ArrayBuffer();
 
         assertEquals(100, result.limit());
         root.close();
@@ -1441,7 +1442,7 @@ public class V8ObjectUtilsTest {
                 + "var root = { 'items' : intsArray };\n"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, "items");
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, "items")).getV8TypedArray();
 
         assertEquals(100, result.length());
         assertEquals((byte) 16, result.get(0));
@@ -1457,7 +1458,7 @@ public class V8ObjectUtilsTest {
                 + "var root = { 'items' : intsArray };\n"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, "items");
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, "items")).getV8TypedArray();
 
         assertEquals(100, result.length());
         assertEquals((short) 16, result.get(0));
@@ -1473,7 +1474,7 @@ public class V8ObjectUtilsTest {
                 + "var root = { 'items' : int8ClampedArray };\n"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, "items");
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, "items")).getV8TypedArray();
 
         assertEquals(100, result.length());
         assertEquals((short) 16, result.get(0));
@@ -1489,7 +1490,7 @@ public class V8ObjectUtilsTest {
                 + "var root = { 'items' : intsArray };\n"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, "items");
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, "items")).getV8TypedArray();
 
         assertEquals(50, result.length());
         assertEquals((short) 16, result.get(0));
@@ -1505,7 +1506,7 @@ public class V8ObjectUtilsTest {
                 + "var root = { 'items' : intsArray };\n"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, "items");
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, "items")).getV8TypedArray();
 
         assertEquals(50, result.length());
         assertEquals(16, result.get(0));
@@ -1521,7 +1522,7 @@ public class V8ObjectUtilsTest {
                 + "var root = { 'items' : intsArray };\n"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, "items");
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, "items")).getV8TypedArray();
 
         assertEquals(25, result.length());
         assertEquals(16, result.get(0));
@@ -1537,7 +1538,7 @@ public class V8ObjectUtilsTest {
                 + "var root = { 'items' : intsArray };\n"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, "items");
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, "items")).getV8TypedArray();
 
         assertEquals(25, result.length());
         assertEquals((long) 16, result.get(0));
@@ -1553,7 +1554,7 @@ public class V8ObjectUtilsTest {
                 + "var root = { 'items' : floatsArray };"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, "items");
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, "items")).getV8TypedArray();
 
         assertEquals(25, result.length());
         assertEquals(16.2, (Float) result.get(0), 0.00001);
@@ -1569,7 +1570,7 @@ public class V8ObjectUtilsTest {
                 + "var root = { 'items' : floatsArray };\n"
                 + "root;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(root, "items");
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(root, "items")).getV8TypedArray();
 
         assertEquals(10, result.length());
         assertEquals(16.2, (Double) result.get(0), 0.0001);
@@ -1577,111 +1578,110 @@ public class V8ObjectUtilsTest {
         result.close();
     }
 
-    /*
+
     @Test
     public void testTypedArrayInMap() {
-        Int8Array int8Array = new Int8Array(ByteBuffer.allocateDirect(8));
-        int8Array.put(0, (byte) 7);
+        TypedArray int8Array = new TypedArray(v8, new ArrayBuffer(v8, ByteBuffer.allocateDirect(8)), V8Value.INT_8_ARRAY, 0, 8);
+        V8TypedArray v8TypedArray = int8Array.getV8TypedArray();
+        V8ArrayBuffer v8ArrayBuffer = v8TypedArray.getBuffer();
+        v8ArrayBuffer.put(0, (byte) 7);
+        v8TypedArray.close();
+        v8ArrayBuffer.close();
         HashMap<String, Object> map = new HashMap<String, Object>();
         map.put("array", int8Array);
 
         V8Object object = V8ObjectUtils.toV8Object(v8, map);
 
         V8TypedArray v8Array = (V8TypedArray) object.get("array");
-        assertEquals(7, v8Array.get(0));
+        assertEquals((byte) 7, v8Array.get(0));
         assertEquals(V8Value.INT_8_ARRAY, v8Array.getType());
         v8Array.close();
         object.close();
     }
-    */
 
-    /*
     @Test
     public void testGetTypedArray() {
-        Int8Array int8Array = new Int8Array(ByteBuffer.allocateDirect(8));
-        int8Array.put(0, (byte) 7);
+        TypedArray int8Array = new TypedArray(v8, new ArrayBuffer(v8, ByteBuffer.allocateDirect(8)), V8Value.INT_8_ARRAY, 0, 8);
+        V8TypedArray v8TypedArray = int8Array.getV8TypedArray();
+        V8ArrayBuffer v8ArrayBuffer = v8TypedArray.getBuffer();
+        v8ArrayBuffer.put(0, (byte) 7);
+        v8TypedArray.close();
+        v8ArrayBuffer.close();
 
         V8TypedArray v8Array = (V8TypedArray) V8ObjectUtils.getV8Result(v8, int8Array);
 
-        assertEquals(7, v8Array.get(0));
+        assertEquals((byte) 7, v8Array.get(0));
         assertEquals(V8Value.INT_8_ARRAY, v8Array.getType());
         v8Array.close();
     }
-    */
 
-    /*
     @Test
     public void testByteBufferInMap() {
-        ArrayBuffer arrayBuffer = new ArrayBuffer(8);
+        ArrayBuffer arrayBuffer = new ArrayBuffer(v8, ByteBuffer.allocateDirect(8));
         HashMap<String, Object> map = new HashMap<String, Object>();
         map.put("buffer", arrayBuffer);
 
         V8Object object = V8ObjectUtils.toV8Object(v8, map);
 
         V8ArrayBuffer v8ArrayBuffer = (V8ArrayBuffer) object.get("buffer");
-        assertEquals(arrayBuffer.getByteBuffer(), v8ArrayBuffer.getBackingStore());
+        assertEquals(arrayBuffer.getV8ArrayBuffer().setWeak(), v8ArrayBuffer);
         v8ArrayBuffer.close();
         object.close();
     }
-    */
 
-    /*
     @Test
     public void testArrayBufferInList() {
-        ArrayBuffer arrayBuffer = new ArrayBuffer(8);
+        ArrayBuffer arrayBuffer = new ArrayBuffer(v8, ByteBuffer.allocateDirect(8));
         List<Object> list = new ArrayList<Object>();
         list.add(arrayBuffer);
 
         V8Array array = V8ObjectUtils.toV8Array(v8, list);
 
         V8ArrayBuffer v8ArrayBuffer = (V8ArrayBuffer) array.get(0);
-        assertEquals(arrayBuffer.getByteBuffer(), v8ArrayBuffer.getBackingStore());
+        assertEquals(arrayBuffer.getV8ArrayBuffer().setWeak(), v8ArrayBuffer);
         v8ArrayBuffer.close();
         array.close();
     }
-    */
 
-    /*
     @Test
     public void testGetArrayBuffer() {
-        ArrayBuffer arrayBuffer = new ArrayBuffer(8);
+        ArrayBuffer arrayBuffer = new ArrayBuffer(v8, ByteBuffer.allocateDirect(8));
 
         V8ArrayBuffer v8ArrayBuffer = (V8ArrayBuffer) V8ObjectUtils.getV8Result(v8, arrayBuffer);
 
-        assertEquals(arrayBuffer.getByteBuffer(), v8ArrayBuffer.getBackingStore());
+        assertEquals(arrayBuffer.getV8ArrayBuffer().setWeak(), v8ArrayBuffer);
         v8ArrayBuffer.close();
     }
-    */
 
-    /*
     @Test
     public void testGetArrayBufferNotReleased() {
-        ArrayBuffer arrayBuffer = new ArrayBuffer(8);
+        ArrayBuffer arrayBuffer = new ArrayBuffer(v8, ByteBuffer.allocateDirect(8));
 
         V8ArrayBuffer v8ArrayBuffer = (V8ArrayBuffer) V8ObjectUtils.getV8Result(v8, arrayBuffer);
 
         assertFalse(v8ArrayBuffer.isReleased());
         v8ArrayBuffer.close();
     }
-    */
 
-    /*
     @Test
     public void testTypedArrayInList() {
-        Int8Array int8Array = new Int8Array(ByteBuffer.allocateDirect(8));
-        int8Array.put(0, (byte) 7);
+        TypedArray int8Array = new TypedArray(v8, new ArrayBuffer(v8, ByteBuffer.allocateDirect(8)), V8Value.INT_8_ARRAY, 0, 8);
+        V8TypedArray v8TypedArray = int8Array.getV8TypedArray();
+        V8ArrayBuffer v8ArrayBuffer = v8TypedArray.getBuffer();
+        v8ArrayBuffer.put(0, (byte) 7);
+        v8TypedArray.close();
+        v8ArrayBuffer.close();
         List<Object> list = new ArrayList<Object>();
         list.add(int8Array);
 
         V8Array array = V8ObjectUtils.toV8Array(v8, list);
 
         V8Array v8Array = (V8Array) array.get(0);
-        assertEquals(7, v8Array.get(0));
+        assertEquals((byte) 7, v8Array.get(0));
         assertEquals(V8Value.INT_8_ARRAY, v8Array.getType());
         v8Array.close();
         array.close();
     }
-    */
 
     @Test
     public void testPushV8ArrayToArray() {
@@ -2414,11 +2414,12 @@ public class V8ObjectUtilsTest {
                 + "intsArray[0] = 16;\n"
                 + "intsArray;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(intsArray);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(intsArray)).getV8TypedArray();
 
         assertEquals(100, result.length());
         assertEquals((byte) 16, result.get(0));
         intsArray.close();
+        result.close();
     }
 
     @Test
@@ -2427,10 +2428,11 @@ public class V8ObjectUtilsTest {
                 + "var intsArray = new Int8Array(24);\n"
                 + "intsArray");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(intsArray);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(intsArray)).getV8TypedArray();
 
         assertEquals(24, result.length());
         intsArray.close();
+        result.close();
     }
 
     @Test
@@ -2440,11 +2442,12 @@ public class V8ObjectUtilsTest {
                 + "intsArray[0] = 16;\n"
                 + "intsArray;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(intsArray);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(intsArray)).getV8TypedArray();
 
         assertEquals(100, result.length());
         assertEquals((short) 16, result.get(0));
         intsArray.close();
+        result.close();
     }
 
     @Test
@@ -2454,11 +2457,12 @@ public class V8ObjectUtilsTest {
                 + "int8ClampedArray[0] = 16;\n"
                 + "int8ClampedArray;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(int8ClampedArray);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(int8ClampedArray)).getV8TypedArray();
 
         assertEquals(100, result.length());
         assertEquals((short) 16, result.get(0));
         int8ClampedArray.close();
+        result.close();
     }
 
     @Test
@@ -2468,11 +2472,12 @@ public class V8ObjectUtilsTest {
                 + "intsArray[0] = 16;\n"
                 + "intsArray;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(intsArray);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(intsArray)).getV8TypedArray();
 
         assertEquals(50, result.length());
         assertEquals((short) 16, result.get(0));
         intsArray.close();
+        result.close();
     }
 
     @Test
@@ -2482,11 +2487,12 @@ public class V8ObjectUtilsTest {
                 + "intsArray[0] = 16;\n"
                 + "intsArray;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(intsArray);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(intsArray)).getV8TypedArray();
 
         assertEquals(50, result.length());
         assertEquals(16, result.get(0));
         intsArray.close();
+        result.close();
     }
 
     @Test
@@ -2496,11 +2502,12 @@ public class V8ObjectUtilsTest {
                 + "intsArray[0] = 16;\n"
                 + "intsArray;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(intsArray);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(intsArray)).getV8TypedArray();
 
         assertEquals(25, result.length());
         assertEquals(16, result.get(0));
         intsArray.close();
+        result.close();
     }
 
     @Test
@@ -2510,11 +2517,12 @@ public class V8ObjectUtilsTest {
                 + "intsArray[0] = 16;\n"
                 + "intsArray;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(intsArray);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(intsArray)).getV8TypedArray();
 
         assertEquals(25, result.length());
         assertEquals(16L, result.get(0));
         intsArray.close();
+        result.close();
     }
 
     @Test
@@ -2524,11 +2532,12 @@ public class V8ObjectUtilsTest {
                 + "floatsArray[0] = 16.2;\n"
                 + "floatsArray;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(floatsArray);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(floatsArray)).getV8TypedArray();
 
         assertEquals(25, result.length());
         assertEquals(16.2, (Float) result.get(0), 0.00001);
         floatsArray.close();
+        result.close();
     }
 
     @Test
@@ -2538,11 +2547,12 @@ public class V8ObjectUtilsTest {
                 + "floatsArray[0] = 16.2;\n"
                 + "floatsArray;\n");
 
-        V8TypedArray result = (V8TypedArray) V8ObjectUtils.getValue(floatsArray);
+        V8TypedArray result = ((TypedArray) V8ObjectUtils.getValue(floatsArray)).getV8TypedArray();
 
         assertEquals(10, result.length());
         assertEquals(16.2, (Double) result.get(0), 0.0001);
         floatsArray.close();
+        result.close();
     }
 
     @Test
@@ -2550,10 +2560,11 @@ public class V8ObjectUtilsTest {
         V8ArrayBuffer buf = (V8ArrayBuffer) v8.executeScript("var buf = new ArrayBuffer(100);\n"
                 + "buf;\n");
 
-        V8ArrayBuffer result = (V8ArrayBuffer) V8ObjectUtils.getValue(buf);
+        V8ArrayBuffer result = ((ArrayBuffer) V8ObjectUtils.getValue(buf)).getV8ArrayBuffer();
 
         assertEquals(100, result.limit());
         buf.close();
+        result.close();
     }
 
     @SuppressWarnings("unchecked")
@@ -2682,6 +2693,7 @@ public class V8ObjectUtilsTest {
     public void testObjectUndefinedTypeAdapter_Map_GetValue() {
         V8Object object = v8.executeObjectScript("x = {b:{a:{}}}; x");
 
+        @SuppressWarnings("resource")
         V8Value result = (V8Value) V8ObjectUtils.getValue(object, new SingleTypeAdapter(V8Value.V8_OBJECT) {
 
             @Override


### PR DESCRIPTION
The V8TypedArrays and V8ArrayBuffers contain handles to V8
objects which must be released. This change-set adds
lightweight wrappers for these two objects. These lightweight
wrappers have no underlying resource associated with them
and do not have to be released.

If the objects which they wrap are accessed, those objects
must be released.