### PR TITLE
Add missing requirements and improve bash script

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,5 +1,12 @@
 # Getting started / building from source
 
+#### Requirements
+
+1. Python 2
+2. Docker (*only required for building using Docker)
+
+#### Build
+
 1. clone the source code from the [J2V8 GitHub repository](https://github.com/eclipsesource/J2V8)
 2. run `j2v8-cli.cmd` (on Win32) or `source j2v8-cli.sh` on MacOS / Linux
 3. `nodejs git clone` to clone the Node.js/V8 source code
@@ -10,9 +17,14 @@
 
 ## Interactive
 ```shell
-build --i, --interactive
+build -i, --interactive
 # or
-python build.py --i, --interactive
+
+###### Win32
+python build.py -i, --interactive
+
+###### MacOS / Linux
+python2 build.py -i, --interactive
 
 entering interactive mode...
 

--- a/j2v8-cli.sh
+++ b/j2v8-cli.sh
@@ -1,5 +1,11 @@
+#!/bin/bash
 # This script adds aliases for some of the most often used commands for building J2V8
 # to your current command-shell instance. (can be invoked as "source j2v8-cli.sh")
-alias build="python build.py"
-alias nodejs="python nodejs.py"
-alias citests="python build_system/run_tests.py"
+
+if command -v python2 &>/dev/null; then
+	alias build="python2 build.py"
+	alias nodejs="python2 nodejs.py"
+	alias citests="python2 build_system/run_tests.py"
+else
+	 echo Python 2 is not installed
+fi


### PR DESCRIPTION
* Add requirements section to build guideline.
* Since `Python 2` is required to build, bash script is improved to
verify python2 is installed.
* Fix interactive build arguments typo in Build-System CLI section.