### PR TITLE
Replace ArrayList `.equals()` method with `==` to compare the objects

### DIFF
--- a/src/main/java/com/eclipsesource/v8/utils/MemoryManager.java
+++ b/src/main/java/com/eclipsesource/v8/utils/MemoryManager.java
@@ -31,7 +31,7 @@ public class MemoryManager {
     private MemoryManagerReferenceHandler memoryManagerReferenceHandler;
     private V8                            v8;
     private ArrayList<V8Value>            references = new ArrayList<V8Value>();
-    private boolean                       releasing = false;
+    private boolean                       releasing  = false;
     private boolean                       released   = false;
 
     /**
@@ -73,7 +73,7 @@ public class MemoryManager {
     public void persist(final V8Value object) {
         v8.getLocker().checkThread();
         checkReleased();
-        references.remove(object);
+        memoryManagerReferenceHandler.v8HandleDisposed(object);
     }
 
     /**
@@ -92,7 +92,7 @@ public class MemoryManager {
      */
     public void release() {
         v8.getLocker().checkThread();
-        if (released) {
+        if (isReleased()) {
             return;
         }
         releasing = true;
@@ -109,7 +109,7 @@ public class MemoryManager {
     }
 
     private void checkReleased() {
-        if (released) {
+        if (isReleased()) {
             throw new IllegalStateException("Memory manager released");
         }
     }


### PR DESCRIPTION
MemoryManagerReferenceHandler.v8HandleDisposed method is already
implemented with Iterator to compare the object using `==` instead of
`.equals`. Therefore,
MemoryManagerReferenceHandler.v8HandleDisposed can be used rather than
ArrayList.remove to remove object from references array.

Fix #444