### PR TITLE
Add constructor name method to V8Value

### DIFF
--- a/jni/com_eclipsesource_v8_V8Impl.cpp
+++ b/jni/com_eclipsesource_v8_V8Impl.cpp
@@ -174,6 +174,15 @@ JNIEXPORT jstring JNICALL Java_com_eclipsesource_v8_V8__1getVersion (JNIEnv *env
   return env->NewStringUTF(utfString);
 }
 
+
+JNIEXPORT jstring JNICALL Java_com_eclipsesource_v8_V8__1getConstructorName
+(JNIEnv *env, jobject, jlong v8RuntimePtr, jlong objectHandle) {
+  Isolate* isolate = SETUP(env, v8RuntimePtr, 0);
+  Handle<Object> object = Local<Object>::New(isolate, *reinterpret_cast<Persistent<Object>*>(objectHandle));
+  String::Value unicodeString(object->GetConstructorName());
+  return env->NewString(*unicodeString, unicodeString.length());
+}
+
 Local<String> createV8String(JNIEnv *env, Isolate *isolate, jstring &string) {
   const uint16_t* unicodeString = env->GetStringChars(string, NULL);
   int length = env->GetStringLength(string);

--- a/jni/com_eclipsesource_v8_V8Impl.h
+++ b/jni/com_eclipsesource_v8_V8Impl.h
@@ -557,6 +557,14 @@ JNIEXPORT void JNICALL Java_com_eclipsesource_v8_V8__1setPrototype
 
 /*
  * Class:     com_eclipsesource_v8_V8
+ * Method:    _getConstructorName
+ * Signature: (JJ)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_com_eclipsesource_v8_V8__1getConstructorName
+  (JNIEnv *, jobject, jlong, jlong);
+
+/*
+ * Class:     com_eclipsesource_v8_V8
  * Method:    _getType
  * Signature: (JJ)I
  */

--- a/src/main/java/com/eclipsesource/v8/V8.java
+++ b/src/main/java/com/eclipsesource/v8/V8.java
@@ -1321,6 +1321,10 @@ public class V8 extends V8Object {
         _addArrayNullItem(v8RuntimePtr, arrayHandle);
     }
 
+    protected String getConstructorName(final long v8RuntimePtr, final long objectHandle) {
+        return _getConstructorName(v8RuntimePtr, objectHandle);
+    }
+
     protected int getType(final long v8RuntimePtr, final long objectHandle) {
         return _getType(v8RuntimePtr, objectHandle);
     }
@@ -1518,6 +1522,8 @@ public class V8 extends V8Object {
     private native int _getArrayType(long v8RuntimePtr, long objectHandle);
 
     private native void _setPrototype(long v8RuntimePtr, long objectHandle, long prototypeHandle);
+
+    private native String _getConstructorName(long v8RuntimePtr, long objectHandle);
 
     private native int _getType(long v8RuntimePtr, long objectHandle);
 

--- a/src/main/java/com/eclipsesource/v8/V8Value.java
+++ b/src/main/java/com/eclipsesource/v8/V8Value.java
@@ -144,6 +144,17 @@ abstract public class V8Value implements Releasable {
     }
 
     /**
+     * Returns a constructor name of the V8 Value.
+     *
+     * @return The V8Value constructor name as a string.
+     */
+    public String getConstructorName() {
+        v8.checkThread();
+        v8.checkReleased();
+        return v8.getConstructorName(v8.getV8RuntimePtr(), objectHandle);
+    }
+
+    /**
      * Determines if this value is undefined.
      *
      * @return Returns true if the value is undefined, false otherwise

--- a/src/test/java/com/eclipsesource/v8/V8ObjectTest.java
+++ b/src/test/java/com/eclipsesource/v8/V8ObjectTest.java
@@ -1849,4 +1849,74 @@ public class V8ObjectTest {
         object.close();
     }
 
+    @Test
+    public void testConstructorNameFunction() {
+        v8.executeVoidScript("function Foo() {} var foo = new Foo();");
+        V8Object object = (V8Object) v8.get("foo");
+
+        assertEquals(object.getConstructorName(), "Foo");
+
+        object.close();
+    }
+
+    @Test
+    public void testConstructorNameObject() {
+        v8.executeVoidScript("var foo = new Object()");
+        V8Object object = (V8Object) v8.get("foo");
+
+        assertEquals(object.getConstructorName(), "Object");
+
+        object.close();
+    }
+
+    @Test
+    public void testConstructorNameObject_2() {
+        v8.executeVoidScript("var foo = {}");
+        V8Object object = (V8Object) v8.get("foo");
+
+        assertEquals(object.getConstructorName(), "Object");
+
+        object.close();
+    }
+
+    @Test
+    public void testConstructorNameArray() {
+        v8.executeVoidScript("var foo = []");
+        V8Object object = (V8Object) v8.get("foo");
+
+        assertEquals(object.getConstructorName(), "Array");
+
+        object.close();
+    }
+
+    @Test
+    public void testConstructorNameTypedArray() {
+        v8.executeVoidScript("var foo = new Uint8Array()");
+        V8Object object = (V8Object) v8.get("foo");
+
+        assertEquals(object.getConstructorName(), "Uint8Array");
+
+        object.close();
+    }
+
+    @Test
+    public void testConstructorNameArrayBuffer() {
+        v8.executeVoidScript("var foo = new ArrayBuffer()");
+        V8ArrayBuffer object = (V8ArrayBuffer) v8.get("foo");
+
+        assertEquals(object.getConstructorName(), "ArrayBuffer");
+
+        object.close();
+    }
+
+    @Test
+    public void testConstructorNameMap() {
+        v8.executeVoidScript("var foo = new Map()");
+        V8Object object = (V8Object) v8.get("foo");
+
+        assertEquals(object.getConstructorName(), "Map");
+
+        object.close();
+    }
+
 }


### PR DESCRIPTION
V8 has `GetConstructorName` method that returns the constructor name as
a string, so it's used to get the constructor name of the object.

The unit tests are included but currently, only V8Value object type is supported.

Fix #269