### PR TITLE
Fixed failing assertion when a function invoked through V8Function throws an error

### DIFF
--- a/jni/com_eclipsesource_v8_V8Impl.cpp
+++ b/jni/com_eclipsesource_v8_V8Impl.cpp
@@ -761,7 +761,10 @@ bool invokeFunction(JNIEnv *env, const Local<Context>& context, Isolate* isolate
   Handle<Object> receiver = Local<Object>::New(isolate, *reinterpret_cast<Persistent<Object>*>(receiverHandle));
   Handle<Function> func = Handle<Function>::Cast(object);
   TryCatch tryCatch(isolate);
-  result = func->Call(context, receiver, size, args).ToLocalChecked();
+  MaybeLocal<Value> function_call_result = func->Call(context, receiver, size, args);
+  if (!function_call_result.IsEmpty()) {
+      result = function_call_result.ToLocalChecked();
+  }
   if (args != nullptr) {
     delete(args);
   }

--- a/src/test/java/com/eclipsesource/v8/V8JSFunctionCallTest.java
+++ b/src/test/java/com/eclipsesource/v8/V8JSFunctionCallTest.java
@@ -96,6 +96,18 @@ public class V8JSFunctionCallTest {
         parameters.close();
     }
 
+    @Test(expected = V8ScriptExecutionException.class)
+    public void testCallFunctionThrows() {
+        v8.executeVoidScript("function test() {throw new Error('Error');}");
+        V8Function function = (V8Function) v8.getObject("test");
+
+        try {
+            function.call(v8, null);
+        } finally {
+            function.close();
+        }
+    }
+
     @Test
     public void testCallFunctionNullParameters() {
         v8.executeVoidScript("function call() {return true;}");


### PR DESCRIPTION
Hi all!

When a JS function is invoked through the `V8Function` class, if such function throws an error, the process crashes due to a failed native assertion.

This pull request fixes the crash by checking the the `MaybeLocal` returned by the function call is not empty before trying to access it.

An example is included in the attached test.