### PR TITLE
fixing the wrong reference appoint by issue #444

### DIFF
--- a/src/main/java/com/eclipsesource/v8/utils/MemoryManager.java
+++ b/src/main/java/com/eclipsesource/v8/utils/MemoryManager.java
@@ -73,7 +73,7 @@ public class MemoryManager {
     public void persist(final V8Value object) {
         v8.getLocker().checkThread();
         checkReleased();
-        references.remove(object);
+        memoryManagerReferenceHandler.v8HandleDisposed(object);
     }
 
     /**


### PR DESCRIPTION
Replacing the pre-existent remove that used implicitly `equals` to a `==` based one, utilizing the already implemented `MemoryManagerReferenceHandler.v8HandleDisposed`


Fix [#444](https://github.com/eclipsesource/J2V8/issues/444)
