### PR TITLE
fix(android): align ELF segments to 16 KB pages for Android 15+ compliance (closes #605)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,9 @@ set(CMAKE_CXX_STANDARD 14)
 if(CMAKE_SYSTEM_NAME STREQUAL "Android")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unused-function -Wno-unused-variable -O3 -funroll-loops -ftree-vectorize -ffast-math -fpermissive -fPIC ")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-function -Wno-unused-variable -O3 -funroll-loops -ftree-vectorize -ffast-math -fpermissive -fPIC ")
+    #Align output ELF segments to 16 KB pages for Android 15+
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384")
+
 endif()
 
 # remove the MinSizeRel and RelWithDebInfo configurations

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -37,6 +37,7 @@ LOCAL_SRC_FILES := com_eclipsesource_v8_V8Impl.cpp
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/../node/node.$(TARGET_ARCH_ABI)/deps $(LOCAL_PATH)/../node/node.$(TARGET_ARCH_ABI)/deps/v8 $(LOCAL_PATH)/../node/node.$(TARGET_ARCH_ABI)/deps/v8/include $(LOCAL_PATH)/../node/node.$(TARGET_ARCH_ABI)/deps/icu-small/source 
 LOCAL_CFLAGS	+= -std=c++11 -Wall -Wno-unused-function -Wno-unused-variable -O3 -funroll-loops -ftree-vectorize -ffast-math -fpermissive -fPIC 
 LOCAL_LDLIBS	+= -L$(SYSROOT)/usr/lib -llog -latomic
+LOCAL_LDFLAGS    += -Wl,-z,max-page-size=16384
 
 LOCAL_STATIC_LIBRARIES := \
 	v8_base v8_nosnapshot v8_libplatform v8_libbase v8_libsampler


### PR DESCRIPTION
This pull request updates the Android build process for J2V8 to ensure that all generated ELF binaries are properly aligned to 16 KB page boundaries. This change is necessary to meet new requirements for Android 15+ (API level 35 and above), as outlined in Issue #605. Specifically, I added the linker flag -Wl,-z,max-page-size=16384 to both the CMake and Android.mk build scripts. With these updates, all native libraries produced for Android will be compatible with the upcoming 16 KB page size mandate from Google Play, helping prevent installation or runtime issues on newer devices.

To verify the fix, I rebuilt the native libraries for all Android ABIs and used the recommended alignment check script to confirm that each .so file is now correctly aligned. No other changes were made outside of what was needed for this compliance update. If any further testing or tweaks are needed, please let me know!

https://github.com/eclipsesource/J2V8/issues/605